### PR TITLE
Fix autoprefixer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "license": "ISC",
   "devDependencies": {
     "angular-mocks": "^1.4.8",
+    "autoprefixer": "^6.3.3",
     "bootstrap-loader": "^1.0.1",
     "chai": "^3.4.1",
     "constants": "0.0.2",


### PR DESCRIPTION
In the webpack.config.js we have a require of `autoprefixer` but it is not defined as dev dependency in the package.json