### PR TITLE
Update build configuration to place `index.html` at the correct location

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -68,7 +68,7 @@ module.exports = {
     plugins: [
         new HtmlWebpackPlugin({
             title: 'Nightwing - An Application Framework',
-            filename: './build/index.html',
+            filename: './index.html',
             template: './app/index.html',
             inject: false
         }),


### PR DESCRIPTION
In its current state, the code places `index.html` at `build/build/index.html`.  This change causes it to be placed at the correct location of `build/index.html`.